### PR TITLE
Update composer to work with Laravel 5 and Laravel 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
   ],
   "require": {
     "php": ">=5.6.0",
-    "illuminate/support": "^5.3",
-    "illuminate/routing": "^5.3",
+    "illuminate/support": "^5.3 || ^6.0",
+    "illuminate/routing": "^5.3 || ^6.0",
     "jimdo/prometheus_client_php": "^0.9.0"
   },
   "autoload": {


### PR DESCRIPTION
Update composer to work with Laravel 5 and Laravel 6.

If possible, make a release for this (1.0.4)